### PR TITLE
add react rule for child on new line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@studysync/eslint-plugin-persnickety": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@studysync/eslint-plugin-persnickety/-/eslint-plugin-persnickety-1.0.3.tgz",
+      "integrity": "sha512-WdR/ZA6EJ/cAAWlk5h2foB4hwo/MIVMnuLvS1k5NC27hZMFtr9ijj4XAVWjeriF3gtKWaStQOYK3U5d27k6f0w=="
+    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -109,6 +114,29 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.11.tgz",
+      "integrity": "sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.28.0",
@@ -489,6 +517,12 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "csstype": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
+      "dev": true
     },
     "damerau-levenshtein": {
       "version": "1.0.6",
@@ -1729,6 +1763,16 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -18,16 +18,19 @@
   },
   "homepage": "https://github.com/loveholidays/eslint-config-loveholidays#readme",
   "dependencies": {
+    "@studysync/eslint-plugin-persnickety": "^1.0.3",
     "@typescript-eslint/eslint-plugin": "4.28.0",
     "eslint": "^7.29.0",
-    "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-config-airbnb": "^18.2.1",
+    "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-plugin-import": "^2.23.3",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-hooks": "^4.2.0"
   },
   "devDependencies": {
+    "@types/react": "^17.0.11",
+    "react": "^17.0.2",
     "typescript": "^4.3.4"
   }
 }

--- a/react.js
+++ b/react.js
@@ -3,7 +3,9 @@ module.exports = {
     'eslint-config-airbnb-typescript',
     './base.js',
   ],
-  
+  plugins: [
+    '@studysync/persnickety',
+  ],
   rules: {
     'react/jsx-first-prop-new-line': ['error', 'multiline'],
     'react/jsx-max-props-per-line': ['error', { 'maximum': 1, 'when': 'always' }],
@@ -16,5 +18,6 @@ module.exports = {
     'react/prop-types': 'off',
     'react/no-array-index-key': 'off',
     'react/destructuring-assignment': 'off',
+    '@studysync/persnickety/jsx-child-location': 'error'
   }
 }

--- a/test/react-component.tsx
+++ b/test/react-component.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface ComponentProps {
+}
+
+export const react: React.FC<ComponentProps> = () => (
+  <div
+    data-id="id"
+    data-test-id="test-id"
+  >
+    Hello
+  </div>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "jsx": "preserve",
+    "jsx": "react",
     "module": "esnext",
     "target": "es2019",
     "moduleResolution": "node",
@@ -15,11 +15,10 @@
     "baseUrl": "./test",
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "outDir":"dist"
+    "outDir":"dist",
   },
-  "files": [
-    "node_modules/jest-playwright-preset/types/global.d.ts",
-    "node_modules/expect-playwright/global.d.ts"
+  "typeRoots": [
+    "node_modules/@types",
   ],
   "include": [
     "test/**/*.ts",


### PR DESCRIPTION
fixes https://github.com/loveholidays/eslint-config-loveholidays/issues/36

uses this https://github.com/dkadrios/eslint-plugin-persnickety/blob/master/lib/rules/jsx-child-location.js

as surprisingly the eslint react plugin doesn't have a rule for this.

We can look into maybe creating our own plugin and writing our own custom rules.