### PR TITLE
Changing `react/jsx-fragments` to force usage of simple fragment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+.idea

--- a/react.js
+++ b/react.js
@@ -11,7 +11,7 @@ module.exports = {
     'react/jsx-max-props-per-line': ['error', { 'maximum': 1, 'when': 'always' }],
     'react/jsx-indent': ['error', 2, { checkAttributes: true, indentLogicalExpressions: true }],
     'react/jsx-curly-spacing': ['error', 'never'],
-    'react/jsx-fragments': ['error', 'element'],
+    'react/jsx-fragments': ['error', 'syntax'],
     'react/jsx-key': 'error',
     'react/jsx-one-expression-per-line': 'off',
     'react/jsx-props-no-spreading': 'off',


### PR DESCRIPTION
https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md
Offer to switch `react/jsx-fragments` rule to `syntax` mode.

Examples of incorrect code for this rule:
`<React.Fragment><Foo /></React.Fragment>`
Examples of correct code for this rule:
`<><Foo /></>`