### PR TITLE
Bump version of react in eslint config

### DIFF
--- a/react.js
+++ b/react.js
@@ -9,7 +9,7 @@ module.exports = {
   ],
   settings: {
     react: {
-      version: '16'
+      version: '16.2'
     }
   },
   rules: {


### PR DESCRIPTION
to resolve this issue 

`  82:5  warning  Fragments are only supported starting from React v16.2. Please disable the `react/jsx-fragments` rule in `eslint` settings or upgrade your version of React  react/jsx-fragments`