### PR TITLE
enforce boolean attributes notation in JSX

### DIFF
--- a/react.js
+++ b/react.js
@@ -27,6 +27,6 @@ module.exports = {
     'react/destructuring-assignment': 'off',
     'react/require-default-props': 'off',
     '@studysync/persnickety/jsx-child-location': 'error',
-    'react/jsx-boolean-value': 2
+    'react/jsx-boolean-value': 'error'
   }
 }

--- a/react.js
+++ b/react.js
@@ -27,5 +27,6 @@ module.exports = {
     'react/destructuring-assignment': 'off',
     'react/require-default-props': 'off',
     '@studysync/persnickety/jsx-child-location': 'error',
+    'react/jsx-boolean-value': 2
   }
 }


### PR DESCRIPTION
## Description
This rule enforces boolean attribute notation in JSX. The rule is auto-fixable.

## Example
### Incorrect
`<Button isDisabled={true} />`

### Correct
`<Button isDisabled />`

