### PR TITLE
Revert "Increase max-len line length linter to 120 characters"

### DIFF
--- a/base.js
+++ b/base.js
@@ -47,7 +47,7 @@ module.exports = {
     'comma-dangle': ['error', 'always-multiline'],
     '@typescript-eslint/comma-dangle': ['error', 'always-multiline'],
     'max-len': ['error', {
-      code: 120,
+      code: 100,
       ignoreComments: true,
       ignoreUrls: true,
       ignoreStrings: true,


### PR DESCRIPTION
Reverts loveholidays/eslint-config-loveholidays#298

Reverting this back to 100, as that's what we are using in digital product projects:
- https://github.com/loveholidays/sunrise/blob/master/.vscode/settings.json#L8-L10
- https://github.com/loveholidays/frontier/blob/master/.vscode/settings.json#L8-L10
- https://github.com/loveholidays/aurora/blob/master/.vscode/settings.json#L7C1-L9
- https://github.com/loveholidays/sanity-studio/blob/master/.vscode/settings.json#L8-L10
- etc

@mishamo if you prefer 120 then you can extend this preset in your project and overwrite this rule in the eslint configuration of the project.