### PR TITLE
introduce react/jsx-curly-brace-presence

### DIFF
--- a/base.js
+++ b/base.js
@@ -67,6 +67,10 @@ module.exports = {
     ],
     'curly': ['error', 'all'],
     'key-spacing': 'error',
+    'react/jsx-curly-brace-presence': [
+      'error',
+      { props: 'never', children: 'never', propElementValues: 'always' },
+    ],
 
     // -- Typescript
     '@typescript-eslint/ban-types': [


### PR DESCRIPTION
Propose to add this rule to remove unnecessary braces from props and children

Example:
```JavaScript
<App>{'Hello world'}</App>;
<App prop={'Hello world'} attr={"foo"} />;
```

will be fixed to

```JavaScript
<App>Hello world</App>;
<App prop="Hello world" attr="foo" />;
```

Doc: https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-curly-brace-presence.md