### PR TITLE
fix: package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loveholidays/eslint-config-loveholidays",
-  "version": "107.0.0",
+  "version": "108.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@loveholidays/eslint-config-loveholidays",
-      "version": "107.0.0",
+      "version": "108.0.0",
       "license": "ISC",
       "dependencies": {
         "@studysync/eslint-plugin-persnickety": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loveholidays/eslint-config-loveholidays",
-  "version": "107.0.0",
+  "version": "108.0.0",
   "description": "eslint config for typescript/react projects",
   "keywords": [],
   "author": "",


### PR DESCRIPTION
### Description

Fix for the repo being unable to release new version (example [here](https://github.com/loveholidays/eslint-config-loveholidays/actions/runs/12007671918/job/33468740245)). This is happening because aversion got released but couldn't push the updated version number back to the repo.